### PR TITLE
Add logic to align warmingSite hours with distributing hours 

### DIFF
--- a/service/siteService.js
+++ b/service/siteService.js
@@ -42,6 +42,7 @@ module.exports = {
 	},
 
 	transformPublicTransit: transformPublicTransit,
+	getWarmingSiteStatus: getWarmingSiteStatus
 
 }
 
@@ -74,7 +75,7 @@ mapRecordFields = function(record) {
 		seekingMoneyURL: record.fields.seeking_money_url,
 		noIdNeeded: record.fields.no_id_needed,
 		someInfoRequired: record.fields.some_info_required,
-		warmingSite: record.fields.warming_site,
+		warmingSite: getWarmingSiteStatus(record.fields.automate_warming_site_status, record.fields.currently_open_for_distributing, record.fields.warming_site),
 		publicTransitOptions: transformPublicTransit(record.fields.public_transit),
 		accepting: record.fields.accepting,
 		notAccepting: record.fields.not_accepting,
@@ -93,6 +94,14 @@ transformHours = function(time) {
 		return `${hours}:${minutes} ${ampm}`
 	} else {
 		return time
+	}
+}
+
+function getWarmingSiteStatus(automateWarmingSiteStatus, currentlyOpenForDistributing, warmingSite) {
+	if(automateWarmingSiteStatus) {
+		return currentlyOpenForDistributing === "yes" ? true : undefined
+	} else {
+		return warmingSite
 	}
 }
 

--- a/service/siteService.test.js
+++ b/service/siteService.test.js
@@ -142,3 +142,25 @@ describe("transformPublicTransit", () => {
         expect(result).toBe(undefined)
     })
 })
+
+describe("getWarmingSiteStatus", () => {
+    it('should return true when automate_warming_site_status checkbox is checked and site is currently open for distributing', () => {
+        let result = siteService.getWarmingSiteStatus(true, "yes", undefined)
+        expect(result).toStrictEqual(true)
+    })
+
+    it('should return true when automate_warming_site_status checkbox is unchecked (undefined) and warming_site checkbox is checked', () => {
+        let result = siteService.getWarmingSiteStatus(undefined, "yes", true)
+        expect(result).toStrictEqual(true)
+    })
+
+    it('should return undefined when automate_warming_site_status checkbox is checked and site is not currently open for distributing', () => {
+        let result = siteService.getWarmingSiteStatus(true, "no", undefined)
+        expect(result).toStrictEqual(undefined)
+    })
+
+    it('should return undefined when automate_warming_site_status checkbox is unchecked (undefined) and warming_site checkbox is not checked (undefined)', () => {
+        let result = siteService.getWarmingSiteStatus(undefined, "yes", undefined)
+        expect(result).toStrictEqual(undefined)
+    })
+})


### PR DESCRIPTION
if timeframes match (`automate_warming_site_status` box is checked in DB),  then return true if site is open for distributing in place of what's in `warming_site` checkbox