### PR TITLE
Filter out inactive sites in api call

### DIFF
--- a/airtableClient.js
+++ b/airtableClient.js
@@ -42,6 +42,7 @@ module.exports = {
 		const direction = 'asc'
 		const query = {
 			sort: [{field, direction}],
+			filterByFormula: 'inactive = 0'
 		}
 
 		const wrappedAirtableCall = rateLimiter.wrap(fetchRecords);


### PR DESCRIPTION
Airtable represents booleans as 0 or 1 in the api response so this will return any sites that are not marked as inactive